### PR TITLE
VP-801: Expose PEB temperature sensor as Linux thermal sensor

### DIFF
--- a/arch/arm/boot/dts/qcom/ifc6640-pebble-expansion-board.dtsi
+++ b/arch/arm/boot/dts/qcom/ifc6640-pebble-expansion-board.dtsi
@@ -348,6 +348,19 @@
 
         // Engage!
         status = "ok";
+
+        pex_temp_sensor@48 {
+            // Use drivers/hwmon/lm75.c driver
+            // See Documentation/hwmon/lm75
+            compatible ="ti,tmp75";
+
+            // Device is strapped to A0=A1=A2=GND
+            // This assigns it address 0b1001000 (0x48)
+            reg = <0x48>;   //Slave Address
+
+            // Engage!
+            status = "ok";
+        };
     };
 };
 

--- a/arch/arm64/configs/msm-perf_defconfig
+++ b/arch/arm64/configs/msm-perf_defconfig
@@ -644,3 +644,5 @@ CONFIG_USB_NET_SMSC95XX=y
 CONFIG_USB_SERIAL_FTDI_SIO=y
 # AppOS: Support for Ticker USB serial port emulation
 CONFIG_USB_ACM=y
+# AppOS: Temperature sensor on PEX
+CONFIG_SENSORS_LM75=y

--- a/arch/arm64/configs/msm_defconfig
+++ b/arch/arm64/configs/msm_defconfig
@@ -697,3 +697,5 @@ CONFIG_USB_NET_SMSC95XX=y
 CONFIG_USB_SERIAL_FTDI_SIO=y
 # AppOS: Support for Ticker USB serial port emulation
 CONFIG_USB_ACM=y
+# AppOS: Temperature sensor on PEX
+CONFIG_SENSORS_LM75=y


### PR DESCRIPTION
i.e. shows up as: /sys/bus/i2c/devices/i2c-5/5-0048/hwmon/*/temp1_input