### PR TITLE
VP-1060 disable headphone jack impedance checking

### DIFF
--- a/sound/soc/codecs/wcd-mbhc-v2.c
+++ b/sound/soc/codecs/wcd-mbhc-v2.c
@@ -1505,7 +1505,12 @@ static void wcd_mbhc_swch_irq_handler(struct wcd_mbhc *mbhc)
 		if (mbhc->mbhc_cb->enable_mb_source)
 			mbhc->mbhc_cb->enable_mb_source(codec, true);
 		mbhc->btn_press_intr = false;
-		wcd_mbhc_detect_plug_type(mbhc);
+		if (mbhc->mbhc_cfg->force_jack_type) {
+			pr_notice("%s: 3.5mm jack forced to type %d\n", __func__, mbhc->mbhc_cfg->force_jack_type);
+			wcd_mbhc_report_plug(mbhc, 1, mbhc->mbhc_cfg->force_jack_type);
+		} else {
+			wcd_mbhc_detect_plug_type(mbhc);
+		}
 	} else if ((mbhc->current_plug != MBHC_PLUG_TYPE_NONE)
 			&& !detection_type) {
 		/* Disable external voltage source to micbias if present */

--- a/sound/soc/codecs/wcd-mbhc-v2.h
+++ b/sound/soc/codecs/wcd-mbhc-v2.h
@@ -256,6 +256,7 @@ struct wcd_mbhc_config {
 	int mbhc_micbias;
 	int anc_micbias;
 	bool enable_anc_mic_detect;
+	enum snd_jack_types force_jack_type;
 };
 
 struct wcd_mbhc_intr {

--- a/sound/soc/msm/msm8996.c
+++ b/sound/soc/msm/msm8996.c
@@ -196,6 +196,7 @@ static struct wcd_mbhc_config wcd_mbhc_cfg = {
 	.mbhc_micbias = MIC_BIAS_2,
 	.anc_micbias = MIC_BIAS_2,
 	.enable_anc_mic_detect = false,
+	.force_jack_type = SND_JACK_HEADSET, // Force jack to always be detected as a "headset"
 };
 
 static inline int param_is_mask(int p)


### PR DESCRIPTION
Follow on from PR #16, turns out impedance checking is done in multiple places... and some places don't pay attention to the `impedance_det_en` flag... 

Provide a way to avoid using `wcd_mbhc_detect_plug_type` completely.

This means we can force a specific plug event, in this case, headset :)