### PR TITLE
AOS-144: Inforce thermal patches

### DIFF
--- a/arch/arm/boot/dts/qcom/msm-pm8994.dtsi
+++ b/arch/arm/boot/dts/qcom/msm-pm8994.dtsi
@@ -33,7 +33,7 @@
 			interrupts = <0x0 0x24 0x0>;
 			label = "pm8994_tz";
 			qcom,channel-num = <8>;
-			qcom,threshold-set = <0>;
+			qcom,threshold-set = <3>;
 			qcom,temp_alarm-vadc = <&pm8994_vadc>;
 		};
 

--- a/arch/arm/boot/dts/qcom/msm8996.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8996.dtsi
@@ -2759,25 +2759,25 @@
 	mitigation_profile0: qcom,limit_info-0 {
 		qcom,temperature-sensor = <&sensor_information4>;
 		qcom,boot-frequency-mitigate;
-		qcom,hotplug-mitigation-enable;
+	//	qcom,hotplug-mitigation-enable;
 	};
 
 	mitigation_profile1: qcom,limit_info-1 {
 		qcom,temperature-sensor = <&sensor_information6>;
 		qcom,boot-frequency-mitigate;
-		qcom,hotplug-mitigation-enable;
+	//	qcom,hotplug-mitigation-enable;
 	};
 
 	mitigation_profile2: qcom,limit_info-2 {
 		qcom,temperature-sensor = <&sensor_information9>;
 		qcom,boot-frequency-mitigate;
-		qcom,hotplug-mitigation-enable;
+	//	qcom,hotplug-mitigation-enable;
 	};
 
 	mitigation_profile3: qcom,limit_info-3 {
 		qcom,temperature-sensor = <&sensor_information11>;
 		qcom,boot-frequency-mitigate;
-		qcom,hotplug-mitigation-enable;
+	//	qcom,hotplug-mitigation-enable;
 	};
 
 	qcom,msm-thermal {
@@ -2787,11 +2787,11 @@
 		qcom,poll-ms = <100>;
 		qcom,limit-temp = <80>;
 		qcom,temp-hysteresis = <10>;
-		qcom,therm-reset-temp = <115>;
+		qcom,therm-reset-temp = <125>;
 		qcom,freq-step = <4>;
 		qcom,core-limit-temp = <90>;
 		qcom,core-temp-hysteresis = <10>;
-		qcom,hotplug-temp = <105>;
+		qcom,hotplug-temp = <125>;
 		qcom,hotplug-temp-hysteresis = <40>;
 		qcom,freq-mitigation-temp = <90>;
 		qcom,freq-mitigation-temp-hysteresis = <40>;
@@ -2801,8 +2801,8 @@
 		qcom,synchronous-cluster-map = <0 2 &CPU0 &CPU1>,
 			<1 2 &CPU2 &CPU3>;
 
-		qcom,vdd-restriction-temp = <5>;
-		qcom,vdd-restriction-temp-hysteresis = <10>;
+		qcom,vdd-restriction-temp = <0>;
+		qcom,vdd-restriction-temp-hysteresis = <5>;
 
 		vdd-dig-supply = <&pm8994_s1_floor_corner>;
 		vdd-gfx-supply = <&gfx_vreg>;


### PR DESCRIPTION
Apply the following two patches:
`0019-dts-modified-thermal-settings-for-IFC66XX.patch` from `Inforce-IFC6640-AndroidBSP-880493-Rel-v2.1`
And
`0024-Thermal-changes-to-enable-cold-boot-above-65C.patch` from `SEN6640-Patch-Relase-880591-Rel-v1.0`

These patches applied cleanly, and the resulting build seems to work.
I can't vouch for if these actually fix anything to do with the operating temperature ranges of the board, but the changes do seem to make sense.